### PR TITLE
Adds a way to set non-boolean build settings.

### DIFF
--- a/lib/crafter.rb
+++ b/lib/crafter.rb
@@ -54,10 +54,15 @@ module Crafter
     @options = options
   end
 
+  def set_build_settings(build_settings)
+    @build_settings = build_settings
+  end
+
   def setup_project
     process_optional()
-    process_configurations() unless @configuration.empty?
-    process_options() unless @options.empty?
+    process_configurations() if @configuration unless @configuration.empty?
+    process_options() if @options unless @options.empty?
+    process_build_settings() if @build_settings unless @build_settings.empty? 
     process_git() if @add_git_ignore
     process_pods()
     process_scripts()
@@ -75,6 +80,11 @@ module Crafter
   def process_options
     puts 'setting up variety of options'
     self.project.enable_options(@options)
+  end
+
+  def process_build_settings
+    puts 'set specified values for build settings'
+    self.project.set_build_settings(@build_settings)
   end
 
   def process_git

--- a/lib/project_helper.rb
+++ b/lib/project_helper.rb
@@ -17,6 +17,15 @@ class ProjectHelper
     save_changes
   end
 
+  def set_build_settings(build_settings)
+    @project.build_configurations.each do |configuration|
+      build_settings.each do |key,value|
+        configuration.build_settings[key] = value
+      end
+    end
+    save_changes
+  end
+
   def add_shell_script(target, name, script)
     if target.shell_script_build_phases.to_a.index { |phase| phase.name == name }
       puts "Skipping adding \"#{name}\" script for target #{target} as it already exist"


### PR DESCRIPTION
Hi!
As discussed on Twitter, I am here now with the pull request.
I added a way to set non-boolean build settings with Crafter. Although the way via 'options' is somehow redundant, I kept it because Crafter is a library and I don't want to force any user to change their configuration files.
Here is an example how to use it in the config:
set_build_settings ({
    :'OTHER_CFLAGS' => '-Wall'
})
I added a few checks too. In case someone wan't use 'options' or 'build_settings' in the config file.
Hope that is all ok with you.

Best,
Stephan
