### PR TITLE
Fix operator precedence bug

### DIFF
--- a/lib/crafter.rb
+++ b/lib/crafter.rb
@@ -60,9 +60,9 @@ module Crafter
 
   def setup_project
     process_optional()
-    process_configurations() if @configuration unless @configuration.empty?
-    process_options() if @options unless @options.empty?
-    process_build_settings() if @build_settings unless @build_settings.empty? 
+    process_configurations() if @configuration && !@configuration.empty?
+    process_options() if @options && !@options.empty?
+    process_build_settings() if @build_settings && !@build_settings.empty?
     process_git() if @add_git_ignore
     process_pods()
     process_scripts()


### PR DESCRIPTION
Would fail with "undefined method `empty?' for nil:NilClass" if `@build_settings` was `nil`.

I prefer explicit "old school" operators in this case, but it could also work reversing it: `... unless @build_settings.empty? if @build_settings`
