### PR TITLE
Updating gemspec's xcodeproj version

### DIFF
--- a/craft.gemspec
+++ b/craft.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = 'crafter'
-  gem.version       = '0.1.4.1'
+  gem.version       = '0.2'
   gem.authors       = ['Krzysztof Zabłocki']
   gem.email         = ['merowing2@gmail.com']
   gem.description   = %q{CLI for setting up new Xcode projects. Inspired by thoughtbot liftoff.}
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/krzysztofzablocki/crafter'
   gem.license = 'MIT'
 
-  gem.add_dependency 'xcodeproj', '~> 0.5.5'
+  gem.add_dependency 'xcodeproj', '~> 1.4.1'
   gem.add_dependency 'highline', '~> 1.6'
 
   gem.files         = `git ls-files`.split($/)

--- a/craft.gemspec
+++ b/craft.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/krzysztofzablocki/crafter'
   gem.license = 'MIT'
 
-  gem.add_dependency 'xcodeproj', '~> 1.4.1'
+  gem.add_dependency 'xcodeproj', '~> 1.4'
   gem.add_dependency 'highline', '~> 1.6'
 
   gem.files         = `git ls-files`.split($/)

--- a/lib/config/default.rb
+++ b/lib/config/default.rb
@@ -4,9 +4,9 @@ load "#{Crafter::ROOT}/config/default_scripts.rb"
 Crafter.configure do
 
   # This are projects wide instructions
-  add_platform({:platform => :ios, :deployment => 6.0})
+  add_platform({:platform => :ios, :deployment => 8.0})
   add_git_ignore
-  duplicate_configurations({:adhoc => :debug, :profiling => :debug})
+  duplicate_configurations({:Adhoc => :Release})
 
   # set of options, warnings, static analyser and anything else normal xcode treats as build options
   set_options %w(

--- a/lib/git_helper.rb
+++ b/lib/git_helper.rb
@@ -22,20 +22,20 @@
 #WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 GITIGNORE_CONTENTS = <<GITIGNORE
-#
-## Mac Finder specific (in case it's not elsewhere)
+
+#### Mac Finder specific (in case it's not elsewhere)
 .DS_Store
-#
-#
-## Xcode
-#
+
+
+#### Xcode
+
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
-#
-## Build generated
+
+#### Build generated
 build/
 DerivedData/
-#
-## Various settings
+
+#### Various settings
 *.pbxuser
 !default.pbxuser
 *.mode1v3
@@ -45,62 +45,62 @@ DerivedData/
 *.perspectivev3
 !default.perspectivev3
 xcuserdata/
-#
-## Other
+
+#### Other
 *.moved-aside
 *.xcuserstate
-#
-## Obj-C/Swift specific
+
+#### Obj-C/Swift specific
 *.hmap
 *.ipa
 *.dSYM.zip
 *.dSYM
-#
-## Automatic backup files
+
+#### Automatic backup files
 *~.nib/
 *.swp
 *~
 *.dat
 *.dep
-#
-#
-## CocoaPods
-#
+
+
+#### CocoaPods
+
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
-#
+
 Pods/
-#
-#
-## Carthage
-#
+
+
+#### Carthage
+
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
 # Carthage/Checkouts
-#
+
 # Carthage/Build
-#
-#
-## fastlane
-#
+
+
+#### fastlane
+
 # It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
 # screenshots whenever they are needed.
 # For more information about the recommended setup visit:
 # https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Gitignore.md
-#
+
 fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
-#
-#
-## Code Injection
-#
+
+
+#### Code Injection
+
 # After new code Injection tools there's a generated folder /iOSInjectionProject
 # https://github.com/johnno1962/injectionforxcode
-#
+
 iOSInjectionProject/
-#
+
 GITIGNORE
 
 GITATTRIBUTES_CONTENTS = '*.pbxproj binary merge=union'
@@ -136,7 +136,6 @@ class GitHelper
     end
 
     new_contents = current_file_contents + contents.split("\n")
-
     File.open(filename, 'w') do |file|
       file.write(new_contents.uniq.join("\n"))
     end

--- a/lib/git_helper.rb
+++ b/lib/git_helper.rb
@@ -22,14 +22,19 @@
 #WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 GITIGNORE_CONTENTS = <<GITIGNORE
-# Xcode
+#
+## Mac Finder specific (in case it's not elsewhere)
+.DS_Store
+#
+#
+## Xcode
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
-
+#
 ## Build generated
 build/
 DerivedData/
-
+#
 ## Various settings
 *.pbxuser
 !default.pbxuser
@@ -40,51 +45,62 @@ DerivedData/
 *.perspectivev3
 !default.perspectivev3
 xcuserdata/
-
+#
 ## Other
 *.moved-aside
 *.xcuserstate
-
+#
 ## Obj-C/Swift specific
 *.hmap
 *.ipa
 *.dSYM.zip
 *.dSYM
-
-# CocoaPods
+#
+## Automatic backup files
+*~.nib/
+*.swp
+*~
+*.dat
+*.dep
+#
+#
+## CocoaPods
 #
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
 #
-# Pods/
-
-# Carthage
+Pods/
+#
+#
+## Carthage
 #
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
 # Carthage/Checkouts
-
-Carthage/Build
-
-# fastlane
+#
+# Carthage/Build
+#
+#
+## fastlane
 #
 # It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
 # screenshots whenever they are needed.
 # For more information about the recommended setup visit:
 # https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Gitignore.md
-
+#
 fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
-
-# Code Injection
+#
+#
+## Code Injection
 #
 # After new code Injection tools there's a generated folder /iOSInjectionProject
 # https://github.com/johnno1962/injectionforxcode
-
+#
 iOSInjectionProject/
-
+#
 GITIGNORE
 
 GITATTRIBUTES_CONTENTS = '*.pbxproj binary merge=union'

--- a/lib/git_helper.rb
+++ b/lib/git_helper.rb
@@ -22,34 +22,68 @@
 #WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 GITIGNORE_CONTENTS = <<GITIGNORE
-# OS X Finder
-.DS_Store
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
-# Xcode per-user config
-*.mode1
-*.mode1v3
-*.mode2v3
-*.perspective
-*.perspectivev3
-*.pbxuser
-xcuserdata
-*.xccheckout
-
-# Build products
+## Build generated
 build/
-*.o
-*.LinkFileList
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xcuserstate
+
+## Obj-C/Swift specific
 *.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
 
-# Automatic backup files
-*~.nib/
-*.swp
-*~
-*.dat
-*.dep
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
 
-# AppCode
-.idea
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Gitignore.md
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots
+fastlane/test_output
+
+# Code Injection
+#
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/
 
 GITIGNORE
 

--- a/lib/project_helper.rb
+++ b/lib/project_helper.rb
@@ -5,7 +5,7 @@ class ProjectHelper
   PROJECTS = Dir.glob('*.xcodeproj')
 
   def initialize
-    @project = Xcodeproj::Project.new(xcode_project_file)
+    @project = Xcodeproj::Project.open(xcode_project_file)
   end
 
   def enable_options(options)
@@ -110,6 +110,6 @@ class ProjectHelper
   end
 
   def save_changes
-    @project.save_as xcode_project_file
+    @project.save xcode_project_file
   end
 end


### PR DESCRIPTION
The newest version of xcodeproj required a few tweaks to the code to get working. One thing to keep in mind, and perhaps something you should write as an example in your default crafter script, is that all set_build_settings() can't be made with ruby symbols anymore. The keys have to be strings (e.g. :'KZBEnv' is not ok):
  set_build_settings({
    'BUNDLE_ID_SUFFIX' => '.dev',
    'BUNDLE_DISPLAY_NAME_SUFFIX' => 'dev',
    'KZBEnv' => 'DEV'
  }, configuration: :Debug)