### PR TITLE
Convert symbols to strings before passing them to nanaimo

### DIFF
--- a/lib/project_helper.rb
+++ b/lib/project_helper.rb
@@ -22,7 +22,7 @@ class ProjectHelper
       build_settings.each do |configuration_name, settings|
         if configuration_name.to_s.downcase == "crafter_common" || configuration.name.downcase == configuration_name.to_s.downcase
           settings.each do |key, value|
-            configuration.build_settings[key] = value
+            configuration.build_settings[key.to_s] = value
           end
         end
       end


### PR DESCRIPTION
Nanaimo blew up with this error:

> `sort': comparison of Array with Array failed

Which was caused by `:KZEnv` being compared with another build configuration key which was a string.

```
:KZEnv <=> "foobar" # => nil
```
